### PR TITLE
Export path to kubectl.sh

### DIFF
--- a/provisioning/files/k8s-devenv.sh
+++ b/provisioning/files/k8s-devenv.sh
@@ -11,7 +11,7 @@ export KPATH=$HOME/work/kubernetes
 export GOPATH=$KPATH
 export KUBERNETES_SRC_DIR=$KPATH/src/k8s.io/kubernetes
 export KUBERNETES_PROVIDER=vagrant
-export PATH=$HOME/go-tools/bin:$KPATH/bin:$PATH
+export PATH=$HOME/go-tools/bin:$KPATH/bin:$KUBERNETES_SRC_DIR/cluster:$PATH
 
 if systemctl -q is-active virtualbox; then
     export VAGRANT_DEFAULT_PROVIDER=virtualbox


### PR DESCRIPTION
`kubectl.sh` is sometimes used in scrips (like [there](https://github.com/Mirantis/k8s-AppController/blob/a3eb7e7e2c122a26351aaaa74b6b852a3edeba6b/examples/extended/create.sh)) so adding it's location into `$PATH` helps us a bit.
In such situation nested `sh` can not reuse defined later `kubectl` func.
